### PR TITLE
Add available_locales method to backend

### DIFF
--- a/lib/i18n/backend/http.rb
+++ b/lib/i18n/backend/http.rb
@@ -28,6 +28,10 @@ module I18n
         start_polling if @options[:poll]
       end
 
+      def available_locales
+        @translations.keys.map(&:to_sym).select { |l| l != :i18n }
+      end
+
       def stop_polling
         @stop_polling = true
       end


### PR DESCRIPTION
This changeset adds an `available_locales` method to the `I18n::Backend:Http` base class. [I18n](https://github.com/svenfuchs/i18n) expects [this method](https://github.com/svenfuchs/i18n/blob/master/lib/i18n/backend/base.rb#L77-L81):

```rb
# Returns an array of locales for which translations are available
# ignoring the reserved translation meta data key :i18n.
def available_locales
  raise NotImplementedError
end
```

