### PR TITLE
add more stats reporting around download retries and failures

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,6 +11,7 @@ GEM
     addressable (2.5.0)
       public_suffix (~> 2.0, >= 2.0.2)
     bump (0.5.1)
+    byebug (9.0.6)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     faraday (0.9.1)
@@ -41,6 +42,7 @@ PLATFORMS
 
 DEPENDENCIES
   bump
+  byebug
   i18n-backend-http!
   json
   maxitest

--- a/Readme.md
+++ b/Readme.md
@@ -19,6 +19,8 @@ class MyBackend < I18n::Backend::Http
       cache: Rails.cache,
       http_open_timeout: 5, # default: 1
       http_read_timeout: 5, # default: 1
+      http_open_retries: 3, # default: 0
+      http_read_retries: 3, # default: 0
       # exception_handler:  lambda{|e| Rails.logger.error e },
       # memory_cache_size: ??, # default: 10 locales
     }.merge(options))

--- a/i18n-backend-http.gemspec
+++ b/i18n-backend-http.gemspec
@@ -19,5 +19,6 @@ Gem::Specification.new(name, I18n::Backend::Http::VERSION) do |s|
   s.add_development_dependency 'json'
   s.add_development_dependency 'bump'
   s.add_development_dependency 'single_cov'
+  s.add_development_dependency 'byebug'
   s.required_ruby_version = '>= 2.1.0'
 end

--- a/lib/i18n/backend/http.rb
+++ b/lib/i18n/backend/http.rb
@@ -12,6 +12,7 @@ module I18n
       include ::I18n::Backend::Base
       FAILED_GET = {}.freeze
       STATS_NAMESPACE = 'i18n-backend-http'.freeze
+      ALLOWED_STATS = Set[:download_fail, :open_retry, :read_retry].freeze
 
       def initialize(options)
         @options = {
@@ -150,17 +151,8 @@ module I18n
 
       def record(event, options = {})
         return unless statsd = @options[:statsd_client]
-
-        case event
-        when :download_fail
-          statsd.increment("#{STATS_NAMESPACE}.download_failed", tags: options[:tags])
-        when :open_retry
-          statsd.increment("#{STATS_NAMESPACE}.open_retry", tags: options[:tags])
-        when :read_retry
-          statsd.increment("#{STATS_NAMESPACE}.read_retry", tags: options[:tags])
-        else
-          raise "Unknown statsd event type to record"
-        end
+        raise "Unknown statsd event type to record" unless ALLOWED_STATS.include?(event)
+        statsd.increment("#{STATS_NAMESPACE}.#{event}", tags: options[:tags])
       end
     end
   end

--- a/lib/i18n/backend/http.rb
+++ b/lib/i18n/backend/http.rb
@@ -11,11 +11,14 @@ module I18n
     class Http
       include ::I18n::Backend::Base
       FAILED_GET = {}.freeze
+      STATS_NAMESPACE = 'i18n-backend-http'.freeze
 
       def initialize(options)
         @options = {
           http_open_timeout: 1,
           http_read_timeout: 1,
+          http_open_retries: 0,
+          http_read_retries: 0,
           polling_interval: 10*60,
           cache: nil,
           poll: true,
@@ -104,9 +107,14 @@ module I18n
       end
 
       def download_translations(locale, etag:)
-        result, etag = @http_client.download(path(locale), etag: etag)
-        [parse_response(result), etag] if result
+        download_path = path(locale)
+
+        with_retry do
+          result, new_etag = @http_client.download(download_path, etag: etag)
+          [parse_response(result), new_etag] if result
+        end
       rescue => e
+        record(:download_fail, tags: ["exception:#{e.class}", "path:#{download_path}"])
         @options.fetch(:exception_handler).call(e)
         [self.class::FAILED_GET, nil]
       end
@@ -122,6 +130,37 @@ module I18n
       # hook for extension with other resolution method
       def lookup_key(translations, key)
         translations[key]
+      end
+
+      def with_retry
+        open_tries ||= 0
+        read_tries ||= 0
+        yield
+      rescue Faraday::ConnectionFailed => e
+        raise unless e.instance_variable_get(:@wrapped_exception).is_a?(Net::OpenTimeout)
+        raise if (open_tries += 1) > @options[:http_open_retries]
+        record :open_retry
+        retry
+      rescue Faraday::TimeoutError => e
+        raise unless e.instance_variable_get(:@wrapped_exception).is_a?(Net::ReadTimeout)
+        raise if (read_tries += 1) > @options[:http_read_retries]
+        record :read_retry
+        retry
+      end
+
+      def record(event, options = {})
+        return unless statsd = @options[:statsd_client]
+
+        case event
+        when :download_fail
+          statsd.increment("#{STATS_NAMESPACE}.download_failed", tags: options[:tags])
+        when :open_retry
+          statsd.increment("#{STATS_NAMESPACE}.open_retry", tags: options[:tags])
+        when :read_retry
+          statsd.increment("#{STATS_NAMESPACE}.read_retry", tags: options[:tags])
+        else
+          raise "Unknown statsd event type to record"
+        end
       end
     end
   end

--- a/lib/i18n/backend/http/etag_http_client.rb
+++ b/lib/i18n/backend/http/etag_http_client.rb
@@ -3,7 +3,7 @@ require 'faraday'
 module I18n
   module Backend
     class Http
-      class I18n::Backend::Http::EtagHttpClient
+      class EtagHttpClient
         STATS_NAMESPACE = 'i18n-backend-http.etag_client'.freeze
 
         def initialize(options)


### PR DESCRIPTION
Add some retry logic around open and read failures and report that information to statsd client if it is present.

/cc @grosser 